### PR TITLE
docs: add flow HTTP examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requires **Node.js 20+**, **glide-mq >= 0.14.0**, and **Valkey 7.0+** (TestQueue
 
 Ordering keys, rate limiting, dedup, stall detection, custom job IDs, pluggable serializers, request-reply, serverless producers, Valkey cluster, and more. See [examples/](examples/) for the full list.
 
-Need cross-language access from Python, Go, Ruby, or shell scripts? Start with [HTTP Proxy](examples/http-proxy) for queue routes, queue events SSE, rolling usage summaries, and broadcast publish/SSE over HTTP.
+Need cross-language access from Python, Go, Ruby, or shell scripts? Start with [HTTP Proxy](examples/http-proxy) for queue routes, flow create/read/tree/delete, queue events SSE, rolling usage summaries, and broadcast publish/SSE over HTTP.
 
 ## Links
 

--- a/examples/fastify-api/README.md
+++ b/examples/fastify-api/README.md
@@ -4,7 +4,7 @@ Full REST API + SSE events for glide-mq queue management using `@glidemq/fastify
 
 ## Features
 
-- Full queue HTTP API for jobs, counts, workers, schedulers, flow usage/budget, usage summary, and broadcast routes
+- Full queue HTTP API for jobs, counts, workers, schedulers, flow create/read/tree/delete, flow usage/budget, usage summary, and broadcast routes
 - Server-Sent Events for real-time updates
 - Zod validation (optional)
 - Custom routes with direct queue access via `app.glidemq`
@@ -15,6 +15,9 @@ Full REST API + SSE events for glide-mq queue management using `@glidemq/fastify
 
 - `POST /api/queues/:name/jobs` - add job
 - `GET /api/queues/:name/events` - queue lifecycle SSE
+- `POST /api/queues/flows` - create a tree flow or DAG over HTTP
+- `GET /api/queues/flows/:id/tree` - inspect the nested flow tree
+- `DELETE /api/queues/flows/:id` - revoke or flag remaining jobs in a flow
 - `GET /api/queues/:name/flows/:id/usage` - flow usage summary
 - `GET /api/queues/:name/flows/:id/budget` - flow budget state
 - `GET /api/queues/usage/summary` - rolling usage summary across queues

--- a/examples/hapi-api/README.md
+++ b/examples/hapi-api/README.md
@@ -4,7 +4,7 @@ Full REST API + SSE events for glide-mq queue management using `@glidemq/hapi`.
 
 ## Features
 
-- Full queue HTTP API for jobs, counts, workers, schedulers, flow usage/budget, usage summary, and broadcast routes
+- Full queue HTTP API for jobs, counts, workers, schedulers, flow create/read/tree/delete, flow usage/budget, usage summary, and broadcast routes
 - Server-Sent Events for real-time updates
 - Joi validation
 - Custom routes with direct queue access via `request.server.glidemq`
@@ -15,6 +15,9 @@ Full REST API + SSE events for glide-mq queue management using `@glidemq/hapi`.
 
 - `POST /api/queues/{name}/jobs` - add job
 - `GET /api/queues/{name}/events` - queue lifecycle SSE
+- `POST /api/queues/flows` - create a tree flow or DAG over HTTP
+- `GET /api/queues/flows/{id}/tree` - inspect the nested flow tree
+- `DELETE /api/queues/flows/{id}` - revoke or flag remaining jobs in a flow
 - `GET /api/queues/{name}/flows/{id}/usage` - flow usage summary
 - `GET /api/queues/{name}/flows/{id}/budget` - flow budget state
 - `GET /api/queues/usage/summary` - rolling usage summary across queues

--- a/examples/hapi-basic/README.md
+++ b/examples/hapi-basic/README.md
@@ -29,4 +29,4 @@ Requires Valkey/Redis on localhost:6379.
 
 ## See also
 
-- [hapi-api](../hapi-api) - uses `@glidemq/hapi` for the full queue HTTP API, usage summaries, and broadcast SSE with zero boilerplate
+- [hapi-api](../hapi-api) - uses `@glidemq/hapi` for the full queue HTTP API, flow create/read/tree/delete, usage summaries, and broadcast SSE with zero boilerplate

--- a/examples/hono-api/README.md
+++ b/examples/hono-api/README.md
@@ -4,7 +4,7 @@ Full REST API + SSE events for glide-mq queue management using `@glidemq/hono`.
 
 ## Features
 
-- Full queue HTTP API for jobs, counts, workers, schedulers, flow usage/budget, usage summary, and broadcast routes
+- Full queue HTTP API for jobs, counts, workers, schedulers, flow create/read/tree/delete, flow usage/budget, usage summary, and broadcast routes
 - Server-Sent Events for real-time updates
 - Type-safe RPC client (optional)
 - Zod validation (optional)
@@ -15,6 +15,9 @@ Full REST API + SSE events for glide-mq queue management using `@glidemq/hono`.
 
 - `POST /api/queues/:name/jobs` - add job
 - `GET /api/queues/:name/events` - queue lifecycle SSE
+- `POST /api/queues/flows` - create a tree flow or DAG over HTTP
+- `GET /api/queues/flows/:id/tree` - inspect the nested flow tree
+- `DELETE /api/queues/flows/:id` - revoke or flag remaining jobs in a flow
 - `GET /api/queues/:name/flows/:id/usage` - flow usage summary
 - `GET /api/queues/:name/flows/:id/budget` - flow budget state
 - `GET /api/queues/usage/summary` - rolling usage summary across queues

--- a/examples/http-proxy/README.md
+++ b/examples/http-proxy/README.md
@@ -26,6 +26,10 @@ npx tsx index.ts
 | `GET /queues/:name/jobs/:id` | Get job by ID |
 | `GET /queues/:name/counts` | Get job counts |
 | `GET /queues/:name/events` | Subscribe to queue lifecycle events over SSE |
+| `POST /flows` | Create a tree flow or DAG over HTTP |
+| `GET /flows/:id` | Read the current flow snapshot |
+| `GET /flows/:id/tree` | Read the nested flow tree |
+| `DELETE /flows/:id` | Revoke or flag remaining jobs in a flow |
 | `GET /usage/summary` | Read rolling usage totals across one or more queues |
 | `POST /broadcast/:name` | Publish a broadcast message |
 | `GET /broadcast/:name/events` | Read a durable broadcast subscription over SSE |
@@ -34,12 +38,13 @@ npx tsx index.ts
 
 ## Notes
 
-- The proxy is an Express app - any HTTP client (Python, Go, Ruby, curl) can enqueue jobs, read queue events, publish broadcasts, and query usage summaries.
+- The proxy is an Express app - any HTTP client (Python, Go, Ruby, curl) can enqueue jobs, create flows, read queue events, publish broadcasts, and query usage summaries.
 - Workers are separate Node.js processes that consume from the same queues.
-- Pass `queues: ['allowed', 'names']` to restrict access. The same allowlist applies to queue names in `/usage/summary?queues=...` and to `/broadcast/:name`.
+- Pass `queues: ['allowed', 'names']` to restrict access. The same allowlist applies to queue names in `/usage/summary?queues=...`, `/broadcast/:name`, and queue names referenced inside `POST /flows`.
 - Install `express` as a peer dependency alongside `glide-mq`.
 - The proxy supports all job options: `delay`, `priority`, `attempts`, `jobId`, etc.
 - Broadcast SSE requires a durable `subscription` query param and supports optional `subjects=orders.*,...` filtering.
+- `POST /flows` accepts tree flows with optional `budget` plus DAG payloads. HTTP budgets are currently supported for tree flows only.
 
 ## Example: enqueue from curl
 

--- a/examples/http-proxy/index.ts
+++ b/examples/http-proxy/index.ts
@@ -166,11 +166,17 @@ async function httpPost<T = unknown>(path: string, body: unknown): Promise<T> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+  if (!res.ok) {
+    throw new Error(`POST ${path} failed: ${res.status} ${await res.text()}`);
+  }
   return res.json() as Promise<T>;
 }
 
 async function httpGet<T = unknown>(path: string): Promise<T> {
   const res = await fetch(`http://localhost:${PORT}${path}`);
+  if (!res.ok) {
+    throw new Error(`GET ${path} failed: ${res.status} ${await res.text()}`);
+  }
   return res.json() as Promise<T>;
 }
 
@@ -178,6 +184,12 @@ async function httpDelete<T = unknown>(path: string): Promise<T> {
   const res = await fetch(`http://localhost:${PORT}${path}`, {
     method: 'DELETE',
   });
+  if (!res.ok) {
+    throw new Error(`DELETE ${path} failed: ${res.status} ${await res.text()}`);
+  }
+  if (res.status === 204) {
+    return undefined as T;
+  }
   return res.json() as Promise<T>;
 }
 

--- a/examples/http-proxy/index.ts
+++ b/examples/http-proxy/index.ts
@@ -12,6 +12,12 @@ type SseEvent = {
   id?: string;
 };
 
+type FlowCreateResponse = {
+  flowId: string;
+  kind: 'dag' | 'tree';
+  nodeCount: number;
+};
+
 async function readFirstSseEvent(path: string, timeoutMs = 5_000): Promise<SseEvent> {
   const controller = new AbortController();
   const timeoutId = globalThis.setTimeout(() => controller.abort(), timeoutMs);
@@ -100,8 +106,8 @@ async function readFirstSseEvent(path: string, timeoutMs = 5_000): Promise<SseEv
 
 // --- 1. Start the HTTP proxy ---
 // createProxyServer returns an Express app that maps HTTP requests to queue ops.
-// Any language that can make HTTP calls can enqueue jobs, read usage summaries,
-// subscribe to queue events, and publish/consume broadcasts.
+// Any language that can make HTTP calls can enqueue jobs, create flows, read
+// usage summaries, subscribe to queue events, and publish/consume broadcasts.
 // NOTE: Add authentication middleware (API key, JWT) before production use.
 
 const proxy = createProxyServer({
@@ -116,6 +122,10 @@ const server = await new Promise<ReturnType<typeof proxy.app.listen>>((resolve) 
     console.log('  POST   /queues/:name/jobs        - add a job');
     console.log('  POST   /queues/:name/jobs/bulk   - add jobs in bulk');
     console.log('  GET    /queues/:name/events      - queue lifecycle SSE');
+    console.log('  POST   /flows                    - create a tree flow or DAG');
+    console.log('  GET    /flows/:id                - inspect a flow snapshot');
+    console.log('  GET    /flows/:id/tree           - inspect the nested flow tree');
+    console.log('  DELETE /flows/:id                - revoke remaining jobs in a flow');
     console.log('  GET    /usage/summary            - rolling usage summary');
     console.log('  POST   /broadcast/:name          - publish a broadcast message');
     console.log('  GET    /broadcast/:name/events   - durable broadcast SSE');
@@ -150,18 +160,25 @@ orderWorker.on('error', (err) => console.error('[order] Error:', err));
 
 // --- 3. Demo: enqueue via HTTP (simulating a Python/Go/Ruby client) ---
 
-async function httpPost(path: string, body: unknown): Promise<unknown> {
+async function httpPost<T = unknown>(path: string, body: unknown): Promise<T> {
   const res = await fetch(`http://localhost:${PORT}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
-  return res.json();
+  return res.json() as Promise<T>;
 }
 
-async function httpGet(path: string): Promise<unknown> {
+async function httpGet<T = unknown>(path: string): Promise<T> {
   const res = await fetch(`http://localhost:${PORT}${path}`);
-  return res.json();
+  return res.json() as Promise<T>;
+}
+
+async function httpDelete<T = unknown>(path: string): Promise<T> {
+  const res = await fetch(`http://localhost:${PORT}${path}`, {
+    method: 'DELETE',
+  });
+  return res.json() as Promise<T>;
 }
 
 const emailQueueEventPromise = readFirstSseEvent('/queues/emails/events');
@@ -184,8 +201,36 @@ const bulkResult = await httpPost('/queues/orders/jobs/bulk', {
 });
 console.log('POST /queues/orders/jobs/bulk:', bulkResult);
 
+const flowCreate = await httpPost<FlowCreateResponse>('/flows', {
+  budget: { maxTotalTokens: 500, onExceeded: 'pause' },
+  flow: {
+    children: [
+      {
+        data: { subject: 'Order received', to: 'alice@example.com' },
+        name: 'send-confirmation',
+        queueName: 'emails',
+      },
+      {
+        data: { subject: 'Invoice available', to: 'alice@example.com' },
+        name: 'send-invoice',
+        queueName: 'emails',
+      },
+    ],
+    data: { amount: 149.99, orderId: 'ORD-900' },
+    name: 'fulfill-order',
+    queueName: 'orders',
+  },
+});
+console.log('POST /flows:', flowCreate);
+
 // Wait for processing
 await setTimeout(500);
+
+const flowSnapshot = await httpGet(`/flows/${flowCreate.flowId}`);
+console.log(`GET /flows/${flowCreate.flowId}:`, flowSnapshot);
+
+const flowTree = await httpGet(`/flows/${flowCreate.flowId}/tree`);
+console.log(`GET /flows/${flowCreate.flowId}/tree:`, flowTree);
 
 const usageSummary = await httpGet('/usage/summary?queues=emails&windowMs=60000');
 console.log('\nGET /usage/summary?queues=emails&windowMs=60000:', usageSummary);
@@ -209,6 +254,9 @@ console.log('\nGET /queues/emails/counts:', emailCounts);
 
 const orderCounts = await httpGet('/queues/orders/counts');
 console.log('GET /queues/orders/counts:', orderCounts);
+
+const flowDelete = await httpDelete(`/flows/${flowCreate.flowId}`);
+console.log(`DELETE /flows/${flowCreate.flowId}:`, flowDelete);
 
 // Health check
 const health = await httpGet('/health');


### PR DESCRIPTION
## Summary
- expand the HTTP proxy example to demonstrate flow create/read/tree/delete
- update the wrapper example READMEs to advertise the flow HTTP surface
- refresh the examples index and related cross-links for the new proxy contract

## Test Plan
- npm run typecheck --prefix examples/http-proxy

## Related Issues
Related to avifenesh/glide-mq#196